### PR TITLE
Manifest v3 support

### DIFF
--- a/src/firefox_overrides.ts
+++ b/src/firefox_overrides.ts
@@ -32,6 +32,7 @@ export class FirefoxOverrides {
     const DEVTOOLS_DEBUGGER_REMOTE_ENABLED = "devtools.debugger.remote-enabled";
     const DEVTOOLS_DEBUGGER_PROMPT_CONNECTION =
       "devtools.debugger.prompt-connection";
+    const EXTENSIONS_MANIFESTV3_ENABLED = "extensions.manifestV3.enabled";
     const newPrefs = { ...prefs };
 
     const remoteEnabled = prefs[DEVTOOLS_DEBUGGER_REMOTE_ENABLED];
@@ -46,6 +47,13 @@ export class FirefoxOverrides {
       newPrefs[DEVTOOLS_DEBUGGER_PROMPT_CONNECTION] = false;
     } else if (promptConnection !== false) {
       throw new Error(`${DEVTOOLS_DEBUGGER_PROMPT_CONNECTION} must be false`);
+    }
+
+    const manifestV3Enabled = prefs[EXTENSIONS_MANIFESTV3_ENABLED];
+    if (typeof manifestV3Enabled === "undefined") {
+      newPrefs[EXTENSIONS_MANIFESTV3_ENABLED] = true;
+    } else if (manifestV3Enabled !== true) {
+      throw new Error(`${EXTENSIONS_MANIFESTV3_ENABLED} must be true`);
     }
     return newPrefs;
   }

--- a/tests/firefox_overrides.test.ts
+++ b/tests/firefox_overrides.test.ts
@@ -65,15 +65,21 @@ test.describe("userPrefs", () => {
       "browser.search.region": "AU",
       "devtools.debugger.remote-enabled": true,
     });
+    const prefs4 = overrides.userPrefs({
+      "browser.search.region": "AU",
+      "extensions.manifestV3.enabled": true,
+    });
 
     const expected = {
       "browser.search.region": "AU",
       "devtools.debugger.prompt-connection": false,
       "devtools.debugger.remote-enabled": true,
+      "extensions.manifestV3.enabled": true,
     };
     expect(prefs1).toEqual(expected);
     expect(prefs2).toEqual(expected);
     expect(prefs3).toEqual(expected);
+    expect(prefs4).toEqual(expected);
   });
 
   test("should throws an error with defied preferences", () => {
@@ -103,5 +109,11 @@ test.describe("userPrefs", () => {
         "devtools.debugger.remote-enabled": 1,
       });
     }).toThrowError("devtools.debugger.remote-enabled");
+    expect(() => {
+      overrides.userPrefs({
+        "browser.search.region": "AU",
+        "extensions.manifestV3.enabled": false,
+      });
+    }).toThrowError("extensions.manifestV3.enabled");
   });
 });


### PR DESCRIPTION
This change makes firefox able to load an add-on with manifest v3.  That is achieved by set `extensions.manifestV3.enabled: true` into user preferences.  But, automated test does not load MV3 addons, because content scripts does not work well on CI.  See also https://github.com/ueokande/playwright-webextext/issues/168.