### PR TITLE
fix: change supported playwright version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,16 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@playwright/test": "1.26.0",
-    "playwright": "1.26.0"
+    "@playwright/test": ">=1.0.0",
+    "playwright": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": true
+    },
+    "playwright": {
+      "optional": true
+    }
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Replace playwright version in peer dependencies with `>=1.0.0`.  It allow to install stable playwright versions, non-strict version such as 1.26.0.  Playwright allows to install either install `playwright` or `@playwright/test` (microsoft/playwright#23512) and this PR makes peer dependencies optional.

