### PR TITLE
Relax node engine requirement to support Node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "playwright-webextext",
-  "version": "0.0.4",
-  "description": "Playwright extension for tesiting WebExtensions",
+  "version": "0.0.5",
+  "description": "Playwright extension for testing WebExtensions",
   "repository": "git@github.com:ueokande/playwright-webextext.git",
   "author": "Shin'ya Ueoka <ueokande@i-beam.org>",
   "license": "MIT",
   "packageManager": "pnpm@8.14.1",
   "engines": {
-    "node": "20"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
- Summary: Change engines.node from "20" to ">=20" so users running Node 22 (and newer) can install the package without engine errors.
- Rationale: The package appears compatible with Node 22; relaxing the engines avoids installation failures for users on Node 22.
- Change: package.json only.